### PR TITLE
Remove unnecessary require statement

### DIFF
--- a/lib/devise/orm/dynamoid.rb
+++ b/lib/devise/orm/dynamoid.rb
@@ -1,3 +1,1 @@
-require 'orm_adapter-dynamoid'
-
 Dynamoid::Document::ClassMethods.send :include, Devise::Models


### PR DESCRIPTION
was getting an error `require': cannot load such file -- orm_adapter-dynamoid`.  Turns out, this require statement isn't necessary.  Removing it fixes the issue.  